### PR TITLE
Enforce start-up order for containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
     command: './entrypoint.sh'
     environment:
         - USER
+    depends_on:
+        - auth-db
+        - redis
 
   redis:
     image: "redis:5"


### PR DESCRIPTION
Make emba container come up after db and redis containers