### PR TITLE
Server Alias through optargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,25 @@
   <a href="https://twitter.com/intent/tweet?text=Check%20out%20EMBArk%20-%20The%20Firmware%20security%20scanning%20environment!%20https://github.com/e-m-b-a/embark"><img src="https://img.shields.io/twitter/url.svg?style=social&url=https%3A%2F%2Fgithub.com%2Fe-m-b-a%2Fembark"></a>
 </p>
 
-# Important 
+# Important
+
 * The new Tracking application currently doesn't work offline.
-* Device, Vendor and version tracking aren't fully integrated into all dashboards yet.
+* The device, Vendor and version tracking aren't fully integrated into all dashboards yet.
 
 ## Quick-Start
 `git clone https://github.com/e-m-b-a/embark.git; cd embark; sudo ./installer.sh -d`
+
+`sudo ./run-server.sh [-a <IP/HOSTNAME>] [-h]`
 ## About
 
-*EMBArk* is the web based enterprise interface for the firmware security scanner *EMBA*. It is developed to provide the firmware security analyzer *[EMBA](https://github.com/e-m-b-a/emba)* as a containerized service and to ease accessibility to the firmware scanning backend *EMBA* regardless of system and operating system.
-
-Furthermore *EMBArk* improves the data provision by aggregating the various scanning results in an [aggregated management dashboard](https://github.com/e-m-b-a/embark/wiki/Web-interface#main-dashboard).
+*EMBArk* is the web-based enterprise interface for the firmware security scanner *EMBA*. It is developed to provide the firmware security analyzer *[EMBA](https://github.com/e-m-b-a/emba)* as a containerized service and to ease accessibility to the firmware scanning backend *EMBA* regardless of the system and operating system.
+Furthermore, *EMBArk* improves the data provision by aggregating the various scanning results in an [aggregated management dashboard](https://github.com/e-m-b-a/embark/wiki/Web-interface#main-dashboard).
 
 [![Watch EMBArk](https://raw.githubusercontent.com/wiki/e-m-b-a/embark/static/images/EMBArk-YouTube.png)](https://youtu.be/qSHuPWbfhmI "Watch EMBArk")
 
 
 ## Automated setup on Ubuntu 22.04 LTS
+
 1. Checkout the repository (e.g. `git clone https://github.com/e-m-b-a/embark.git`)
 2. Change directory to root of the repository i.e `cd embark`
 3. Run `sudo ./installer.sh -d ` to run the default installation.
@@ -41,8 +44,11 @@ Furthermore *EMBArk* improves the data provision by aggregating the various scan
 To start the EMBArk-Server simply run `$ sudo ./run-server.sh`.
 This starts the http-Server on 0.0.0.0:80
 
+Note: The default server name is "embark.local" and has to be resolved via host files or a DNS-server.\
+If you want to query the server using an IP or other hostname please use the `-a` option. (multiple inputs supported)
+
 ## Developer
-For developers we recommend simply using: `sudo ./installer.sh -F ` and the `./dev-tools/debug-server-start.sh` script.
+For developers, we recommend simply using: `sudo ./installer.sh -F ` and the `./dev-tools/debug-server-start.sh` script.
 
 ## Get involved
 The IoT is growing, the development is ongoing, and there are many new features that we want to add.

--- a/run-server.sh
+++ b/run-server.sh
@@ -100,8 +100,6 @@ for VAR in ${ALIAS_INPUT[@]}; do
   echo "[*] $VAR"
 done
 # echo "${SERVER_ALIAS[*]}"
-exit 0
-
 
 cd "$(dirname "$0")" || exit 1
 import_helper

--- a/run-server.sh
+++ b/run-server.sh
@@ -244,7 +244,7 @@ pipenv run ./manage.py runmodwsgi --user www-embark --group sudo \
 --include-file /var/www/conf/embark.conf \
 --processes 4 --threads 4 \
 --graceful-timeout 5 \
---server-name embark.local ${WSGI_FLAGS[@]} &
+--server-name embark.local "${WSGI_FLAGS[@]}" &
 # --ssl-certificate /var/www/conf/cert/embark.local --ssl-certificate-key-file /var/www/conf/cert/embark.local.key \
 # --https-port "$HTTPS_PORT" &
 #  --https-only --enable-debugger \

--- a/run-server.sh
+++ b/run-server.sh
@@ -78,7 +78,7 @@ while getopts "ha:" OPT ; do
       echo -e "$CYAN-a <IP/Name>$NC Add a server Domain-name alias"
       echo -e "---------------------------------------------------------------------------"
       IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
-      echo -e "$GREEN Suggestion:$NC  sudo ./run-server.sh -a $(hostname) -a $IP"
+      echo -e "$GREEN Suggestion:$NC  sudo ./run-server.sh -a $IP"
       echo -e "$GREEN nslookup:$NC"
       nslookup "$IP"
       exit 0

--- a/run-server.sh
+++ b/run-server.sh
@@ -26,7 +26,6 @@ export HTTP_PORT=80
 export HTTPS_PORT=443
 export BIND_IP='0.0.0.0'
 export FILE_SIZE=2000000000
-export ALIAS_INPUT=()
 export SERVER_ALIAS=()
 
 STRICT_MODE=0
@@ -85,8 +84,7 @@ while getopts "ha:" OPT ; do
       exit 0
       ;;
     a)
-      ALIAS_INPUT+=("$OPTARG")
-      SERVER_ALIAS+=("--server-alias \"""$OPTARG""\"")
+      SERVER_ALIAS+=("$OPTARG")
       ;;
     *)
       echo -e "\\n$ORANGE""$BOLD""No Alias set""$NC\\n"
@@ -96,10 +94,9 @@ done
 
 # Input check
 echo -e "$GREEN Server-alias:$NC"
-for VAR in ${ALIAS_INPUT[@]}; do
+for VAR in ${SERVER_ALIAS[@]}; do
   echo "[*] $VAR"
 done
-echo "${SERVER_ALIAS[*]}"
 
 cd "$(dirname "$0")" || exit 1
 import_helper
@@ -238,7 +235,7 @@ pipenv run ./manage.py runmodwsgi --user www-embark --group sudo \
 --processes 4 --threads 4 \
 --graceful-timeout 5 \
 --server-name embark.local \
-"${SERVER_ALIAS[*]}" &
+"$( for ALIAS in ${SERVER_ALIAS[@]}; do printf "--server-alias $ALIAS "; done )" &
 # --ssl-certificate /var/www/conf/cert/embark.local --ssl-certificate-key-file /var/www/conf/cert/embark.local.key \
 # --https-port "$HTTPS_PORT" &
 #  --https-only --enable-debugger \

--- a/run-server.sh
+++ b/run-server.sh
@@ -77,7 +77,7 @@ while getopts "ha:" OPT ; do
       echo -e "$CYAN-h$NC           Print this help message"
       echo -e "$CYAN-a <IP/Name>$NC Add a server Domain-name alias"
       echo -e "---------------------------------------------------------------------------"
-      if ip addr show eth1 &>/dev/null ; then
+      if ip addr show eth0 &>/dev/null ; then
         IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
         echo -e "$GREEN Suggestion:$NC  sudo ./run-server.sh -a $IP"
         echo -e "$GREEN nslookup helper:$NC"

--- a/run-server.sh
+++ b/run-server.sh
@@ -77,7 +77,7 @@ while getopts "ha:" OPT ; do
       echo -e "$CYAN-h$NC           Print this help message"
       echo -e "$CYAN-a <IP/Name>$NC Add a server Domain-name alias"
       echo -e "---------------------------------------------------------------------------"
-      IP = $(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+      IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
       echo -e "$GREEN Suggestion:$NC  sudo ./run-server.sh -a $(hostname) -a $IP"
       echo -e "$GREEN nslookup:$NC"
       nslookup "$IP"
@@ -87,7 +87,7 @@ while getopts "ha:" OPT ; do
       SERVER_ALIAS+=("$OPTARG")
       ;;
     :)
-      echo -e "$CYAN Usage: $NC[-a <IP/HOSTNAME>]"
+      echo -e "$CYAN Usage: [-a <IP/HOSTNAME>] $NC"
       exit 1
       ;;
     *)
@@ -97,9 +97,9 @@ while getopts "ha:" OPT ; do
 done
 
 # Alias
-if [[ -n $SERVER_ALIAS ]]; then
+if [[ ${#SERVER_ALIAS[@]} -ne 0 ]]; then
   echo -e "$GREEN Server-alias:$NC"
-  for VAR in ${SERVER_ALIAS[@]}; do
+  for VAR in "${SERVER_ALIAS[@]}"; do
     echo "[*] $VAR"
   done
 fi
@@ -233,7 +233,7 @@ sleep 5
 
 echo -e "\n[""$BLUE JOB""$NC""] Starting Apache"
 WSGI_CMD="pipenv run ./manage.py runmodwsgi --user www-embark --group sudo \
---host "$BIND_IP" --port="$HTTP_PORT" --limit-request-body "$FILE_SIZE" \
+--host $BIND_IP --port=$HTTP_PORT --limit-request-body $FILE_SIZE \
 --url-alias /static/ /var/www/static/ \
 --url-alias /media/ /var/www/media/ \
 --allow-localhost --working-directory /var/www/embark/ --server-root /var/www/httpd80/ \
@@ -244,6 +244,7 @@ WSGI_CMD="pipenv run ./manage.py runmodwsgi --user www-embark --group sudo \
 for ALIAS in "${SERVER_ALIAS[@]}"; do
   WSGI_CMD="${WSGI_CMD} --server-alias $ALIAS"
 done
+WSGI_CMD="${WSGI_CMD} &"
 echo "$WSGI_CMD"
 eval "$WSGI_CMD"
 # --ssl-certificate /var/www/conf/cert/embark.local --ssl-certificate-key-file /var/www/conf/cert/embark.local.key \
@@ -257,7 +258,7 @@ sleep 5
 
 
 echo -e "\n""$ORANGE$BOLD""=============================================================""$NC"
-echo -e "\n""$ORANGE$BOLD""Server started on http://embark.local""${ALIAS_INPUT[*]}""$NC"
+echo -e "\n""$ORANGE$BOLD""Server started on http://embark.local with alias:""${ALIAS_INPUT[*]}""$NC"
 echo -e "\n""$ORANGE$BOLD""EMBA logs are under /var/www/emba_logs/<id> ""$NC"
 # echo -e "\n""$ORANGE$BOLD""For SSL you may use https://embark.local (Not recommended for local use)""$NC"
 # echo -e "\n\n""$GREEN$BOLD""the trusted rootCA.key for the ssl encryption is in ./cert""$NC"

--- a/run-server.sh
+++ b/run-server.sh
@@ -26,6 +26,8 @@ export HTTP_PORT=80
 export HTTPS_PORT=443
 export BIND_IP='0.0.0.0'
 export FILE_SIZE=2000000000
+export ALIAS_INPUT=()
+export SERVER_ALIAS=()
 
 STRICT_MODE=0
 
@@ -67,6 +69,40 @@ cleaner() {
 
 
 # main
+echo -e "\\n$ORANGE""$BOLD""EMBArk Startup""$NC\\n""$BOLD=================================================================$NC"
+
+while getopts "ha:" OPT ; do
+  case $OPT in
+    h)
+      echo -e "\\n""$CYAN""USAGE""$NC"
+      echo -e "$CYAN-h$NC           Print this help message"
+      echo -e "$CYAN-a <IP/Name>$NC Add a server Domain-name alias"
+      echo -e "---------------------------------------------------------------------------"
+      IP = $(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+      echo -e "$GREEN Suggestion:$NC  sudo ./run-server.sh -a $(hostname) -a $IP"
+      echo -e "$GREEN nslookup:$NC"
+      nslookup "$IP"
+      exit 0
+      ;;
+    a)
+      ALIAS_INPUT+=("$OPTARG")
+      SERVER_ALIAS+=("--server-alias ""$OPTARG")
+      ;;
+    *)
+      echo -e "\\n$ORANGE""$BOLD""No Alias set""$NC\\n"
+      ;;
+  esac
+done
+
+# Input check
+echo -e "$GREEN Server-alias:$NC"
+for VAR in ${ALIAS_INPUT[@]}; do
+  echo "[*] $VAR"
+done
+# echo "${SERVER_ALIAS[*]}"
+exit 0
+
+
 cd "$(dirname "$0")" || exit 1
 import_helper
 enable_strict_mode "$STRICT_MODE"
@@ -203,7 +239,8 @@ pipenv run ./manage.py runmodwsgi --user www-embark --group sudo \
 --include-file /var/www/conf/embark.conf \
 --processes 4 --threads 4 \
 --graceful-timeout 5 \
---server-name embark.local &
+--server-name embark.local \
+"${SERVER_ALIAS[*]}" &
 # --ssl-certificate /var/www/conf/cert/embark.local --ssl-certificate-key-file /var/www/conf/cert/embark.local.key \
 # --https-port "$HTTPS_PORT" &
 #  --https-only --enable-debugger \
@@ -215,7 +252,7 @@ sleep 5
 
 
 echo -e "\n""$ORANGE$BOLD""=============================================================""$NC"
-echo -e "\n""$ORANGE$BOLD""Server started on http://embark.local""$NC"
+echo -e "\n""$ORANGE$BOLD""Server started on http://embark.local""${ALIAS_INPUT[*]}""$NC"
 echo -e "\n""$ORANGE$BOLD""EMBA logs are under /var/www/emba_logs/<id> ""$NC"
 # echo -e "\n""$ORANGE$BOLD""For SSL you may use https://embark.local (Not recommended for local use)""$NC"
 # echo -e "\n\n""$GREEN$BOLD""the trusted rootCA.key for the ssl encryption is in ./cert""$NC"

--- a/run-server.sh
+++ b/run-server.sh
@@ -77,10 +77,12 @@ while getopts "ha:" OPT ; do
       echo -e "$CYAN-h$NC           Print this help message"
       echo -e "$CYAN-a <IP/Name>$NC Add a server Domain-name alias"
       echo -e "---------------------------------------------------------------------------"
-      IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
-      echo -e "$GREEN Suggestion:$NC  sudo ./run-server.sh -a $IP"
-      echo -e "$GREEN nslookup:$NC"
-      nslookup "$IP"
+      if ip addr show eth1 &>/dev/null ; then
+        IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+        echo -e "$GREEN Suggestion:$NC  sudo ./run-server.sh -a $IP"
+        echo -e "$GREEN nslookup helper:$NC"
+        nslookup "$IP"
+      fi
       exit 0
       ;;
     a)

--- a/run-server.sh
+++ b/run-server.sh
@@ -244,11 +244,10 @@ pipenv run ./manage.py runmodwsgi --user www-embark --group sudo \
 --include-file /var/www/conf/embark.conf \
 --processes 4 --threads 4 \
 --graceful-timeout 5 \
---server-name embark.local \
+--server-name embark.local ${WSGI_FLAGS[@]} &
 # --ssl-certificate /var/www/conf/cert/embark.local --ssl-certificate-key-file /var/www/conf/cert/embark.local.key \
 # --https-port "$HTTPS_PORT" &
 #  --https-only --enable-debugger \
-${WSGI_FLAGS[@]} &
 sleep 5
 
 echo -e "\n[""$BLUE JOB""$NC""] Starting daphne(ASGI) - log to /embark/logs/daphne.log"

--- a/run-server.sh
+++ b/run-server.sh
@@ -86,7 +86,7 @@ while getopts "ha:" OPT ; do
       ;;
     a)
       ALIAS_INPUT+=("$OPTARG")
-      SERVER_ALIAS+=("--server-alias ""$OPTARG")
+      SERVER_ALIAS+=("--server-alias \"""$OPTARG""\"")
       ;;
     *)
       echo -e "\\n$ORANGE""$BOLD""No Alias set""$NC\\n"
@@ -99,7 +99,7 @@ echo -e "$GREEN Server-alias:$NC"
 for VAR in ${ALIAS_INPUT[@]}; do
   echo "[*] $VAR"
 done
-# echo "${SERVER_ALIAS[*]}"
+echo "${SERVER_ALIAS[*]}"
 
 cd "$(dirname "$0")" || exit 1
 import_helper

--- a/run-server.sh
+++ b/run-server.sh
@@ -94,7 +94,7 @@ while getopts "ha:" OPT ; do
 done
 
 # Alias
-if [[ -n $SERVER_ALIAS ]]
+if [[ -n $SERVER_ALIAS ]]; then
   echo -e "$GREEN Server-alias:$NC"
   for VAR in ${SERVER_ALIAS[@]}; do
     echo "[*] $VAR"

--- a/run-server.sh
+++ b/run-server.sh
@@ -27,6 +27,7 @@ export HTTPS_PORT=443
 export BIND_IP='0.0.0.0'
 export FILE_SIZE=2000000000
 export SERVER_ALIAS=()
+export ALIAS_STRING=""
 
 STRICT_MODE=0
 
@@ -92,11 +93,15 @@ while getopts "ha:" OPT ; do
   esac
 done
 
-# Input check
-echo -e "$GREEN Server-alias:$NC"
-for VAR in ${SERVER_ALIAS[@]}; do
-  echo "[*] $VAR"
-done
+# Alias
+if [[ -n $SERVER_ALIAS ]]
+  echo -e "$GREEN Server-alias:$NC"
+  for VAR in ${SERVER_ALIAS[@]}; do
+    echo "[*] $VAR"
+    printf -v ALIAS_STRING "$ALIAS_STRING --server-alias $ALIAS"
+  done
+  echo "$ALIAS_STRING"
+fi
 
 cd "$(dirname "$0")" || exit 1
 import_helper
@@ -235,7 +240,7 @@ pipenv run ./manage.py runmodwsgi --user www-embark --group sudo \
 --processes 4 --threads 4 \
 --graceful-timeout 5 \
 --server-name embark.local \
-"$( for ALIAS in ${SERVER_ALIAS[@]}; do printf "--server-alias $ALIAS "; done )" &
+"${ALIAS_STRING%?}" &
 # --ssl-certificate /var/www/conf/cert/embark.local --ssl-certificate-key-file /var/www/conf/cert/embark.local.key \
 # --https-port "$HTTPS_PORT" &
 #  --https-only --enable-debugger \

--- a/run-server.sh
+++ b/run-server.sh
@@ -98,7 +98,7 @@ if [[ -n $SERVER_ALIAS ]]; then
   echo -e "$GREEN Server-alias:$NC"
   for VAR in ${SERVER_ALIAS[@]}; do
     echo "[*] $VAR"
-    printf -v ALIAS_STRING "$ALIAS_STRING --server-alias $ALIAS"
+    printf -v ALIAS_STRING "$ALIAS_STRING --server-alias $VAR"
   done
   echo "$ALIAS_STRING"
 fi


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
---
Capability to set server-alias via optargs

**What is the current behavior?** (You can also link to an open issue here)
---
server-alias can only be set manually in the script

**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
---
Set alias of LAN facing IP or the DNS-name and connect to EMBArk without manual setup
![image](https://user-images.githubusercontent.com/62940240/201136909-d52489f3-db96-43c0-985d-ef67fb0acaed.png)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
---
No default still works