### PR TITLE
Fixed a crash when showing the logs, but the logs contain non-utf-8 bytes

### DIFF
--- a/embark/dashboard/views.py
+++ b/embark/dashboard/views.py
@@ -118,7 +118,7 @@ def show_log(request, analysis_id):
     log_file_path_ = f"{Path(firmware.path_to_logs).parent}/emba_run.log"
     logger.debug("Taking file at %s and render it", log_file_path_)
     try:
-        with open(log_file_path_, 'r', encoding='utf-8') as log_file_:
+        with open(log_file_path_, 'rb') as log_file_:
             return HttpResponse(content=log_file_, content_type="text/plain")
     except FileNotFoundError:
         return HttpResponseServerError(content="File is not yet available")


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
The server crashes when a log file contains non-utf-8 bytes
![image](https://github.com/e-m-b-a/embark/assets/7045209/fb07366d-81d7-429c-a87d-6138871e1a03)



**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
The server prints the logs
![image](https://github.com/e-m-b-a/embark/assets/7045209/debe67aa-af76-4c91-8b8a-8bdb9ab4a190)



**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


**Other information**:
none