### PR TITLE
fix: make `exec_blocking_ssh` return stdout data properly when logging is used

### DIFF
--- a/embark/workers/update/update.py
+++ b/embark/workers/update/update.py
@@ -34,10 +34,12 @@ def exec_blocking_ssh(client: SSHClient, command: str, log_write: callable = Non
     if status != 0:
         raise paramiko.ssh_exception.SSHException(f"Command failed with status {status}: {command}")
 
-    if log_write:
-        log_write(f"\nInput: {command} \nOutput: {stdout.read().decode().strip()} \nStatus: {str(status)}\n")
+    stdout_str = stdout.read().decode().strip()
 
-    return stdout.read().decode().strip()
+    if log_write:
+        log_write(f"\nInput: {command} \nOutput: {stdout_str} \nStatus: {str(status)}\n")
+
+    return stdout_str
 
 
 def _copy_files(client: SSHClient, dependency: DependencyType, log_write: callable = None):


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes an issue introduced with a35685ee4faf3e59db2264b0010ea4f8bc6e7a25.


**What is the current behavior?** (You can also link to an open issue here)
All calls to `exec_blocking_ssh` from `embark/workers/update/update.py` that pass a logging callable get returned incorrect results.
This is caused by the method calling `read()` twice in those cases.


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
The method returns the same data it also writes to log (same behavior as before a35685ee4faf3e59db2264b0010ea4f8bc6e7a25).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
/