### PR TITLE
Fix: Issue#290 - FileNotFound error for initial entry to embark/updater

### DIFF
--- a/embark/embark/logviewer.py
+++ b/embark/embark/logviewer.py
@@ -247,6 +247,7 @@ class UpdateLogConsumer(LogConsumer):
         if not os.path.isfile(self.log_file_path):
             await self.send_message({"error": "The log file does not exist, yet."})
             await self.close()
+            return
 
         self.line_cache = LineCache(self.log_file_path)
 

--- a/embark/updater/views.py
+++ b/embark/updater/views.py
@@ -170,10 +170,15 @@ def raw_progress(request):
     """
     logger.info("showing log for update")
     # get the file path
-    log_file_path_ = f"{Path(settings.EMBA_LOG_ROOT)}/emba_update.log"
+    log_file_path_ = Path(settings.EMBA_LOG_ROOT) / "emba_update.log"
     logger.debug("Taking file at %s and render it", log_file_path_)
     try:
-        with open(log_file_path_, 'rb') as log_file_:
-            return HttpResponse(content=log_file_, content_type="text/plain")
-    except FileNotFoundError:
-        return HttpResponseServerError(content="File is not yet available")
+        if not log_file_path_.exists():
+            return HttpResponse("File is not yet available", status=202)
+        
+        return HttpResponse(log_file_path_.read_text(), content_type="text/plain")
+        
+    except Exception as e:
+        logger.exception("raw-progress failed: %s", e)
+        return HttpResponseServerError("Internal Log Error")
+        


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
--- 
Bug Fix regarding issue #290 


**What is the current behavior?** (You can also link to an open issue here)
--- 
After initial entry to Updater-site, a FileNotFound error is thrown due to non-existent log-file.


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
--- 
No Error is thrown during entry and no log-file is created until the first "Check EMBA"-call. 
Opening the "Raw EMBA log file" before generating one results in a 202-status on console and a message on page indicating that the file has not yet been created.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
--- 
Change only influences updater (log system) and is quite simple/evasive.


**Other information**:
--- 